### PR TITLE
Include Bybit liquidation ratio in short scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@
 - Sends a Telegram message only when score exceeds `RISK_THRESHOLD`.
 - Single user, no database, in-memory state.
 - Provides a `/short SYMBOL` command that returns a 0..1 score for shorting
-  based on funding rate, price position and open-interest trend.
+  based on funding rate, price position, open-interest trend and recent
+  liquidation imbalance.
 
 - Alerts are sent only when the short score exceeds `0.50` for clearer signals.
 - Alerts include this short score for quick assessment.
+
+### Liquidation data
+
+The short-scoring logic now queries Bybit's `v5/market/liquidation` endpoint to
+approximate the volume of liquidations on each side over the last hour. The
+ratio of short liquidations over total liquidations slightly increases the score
+when shorts are being squeezed. This endpoint can occasionally lag or miss
+events; treat the derived ratio as an indicative signal rather than a precise
+measure.
 
 
 

--- a/short_agent.py
+++ b/short_agent.py
@@ -10,16 +10,22 @@ from risk import calc_short_score
 async def evaluate_short_symbol(client: httpx.AsyncClient, symbol: str) -> float:
     """Return a 0..1 score estimating short potential for *symbol*.
 
-    The score combines three factors:
+    The score combines four factors:
 
     - Funding rate (negative is good for shorts)
     - Position of the current price in its historical range
     - Recent open interest change (falling OI favours shorts)
+    - Ratio of short liquidation volume over total liquidations
     """
 
     funding = await bybit_api.get_current_funding_rate(client, symbol)
     _, _, oi_delta_pct = await bybit_api.get_oi_1h_change(client, symbol)
     pmin, pmax, last_close, _, _ = await bybit_api.get_alltime_range(client, symbol)
     ratio, _ = bybit_api.historical_position_label(last_close, pmin, pmax)
-    return calc_short_score(funding, ratio, oi_delta_pct)
+
+    long_liq, short_liq = await bybit_api.get_liquidation_stats(client, symbol)
+    total = long_liq + short_liq
+    short_liq_ratio = short_liq / total if total else 0.0
+
+    return calc_short_score(funding, ratio, oi_delta_pct, short_liq_ratio)
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -15,7 +15,9 @@ def test_calc_risk_score() -> None:
 
 
 def test_calc_short_score() -> None:
-    high = calc_short_score(-0.01, 0.8, -10)
-    low = calc_short_score(0.01, 0.2, 5)
-    assert high == pytest.approx(0.94, rel=1e-3)
-    assert low == pytest.approx(0.06, rel=1e-3)
+    base = calc_short_score(-0.01, 0.8, -10)
+    high_liq = calc_short_score(-0.01, 0.8, -10, 0.8)
+    low = calc_short_score(0.01, 0.2, 5, 0.1)
+    assert base == pytest.approx(0.94, rel=1e-3)
+    assert high_liq == pytest.approx(1.0, rel=1e-3)
+    assert low == pytest.approx(0.08, rel=1e-3)


### PR DESCRIPTION
## Summary
- query Bybit liquidation endpoint and compute long/short volumes
- incorporate short liquidation ratio into `calc_short_score`
- use liquidation data in short evaluation and alerts
- document API reliability and extend tests for liquidation scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a60bc76b4c8327a5be1bc62a614ae8